### PR TITLE
Login page ripple source correction

### DIFF
--- a/qortal-ui-core/src/components/login-view/login-section.js
+++ b/qortal-ui-core/src/components/login-view/login-section.js
@@ -617,9 +617,12 @@ class LoginSection extends connect(store)(LitElement) {
 
         // First decrypt...
         this.loadingRipple.welcomeMessage = this.renderPrepareText()
+        const x = e.clientX !== undefined ? e.clientX : e.explicitOriginalTarget.getBoundingClientRect().left + window.scrollX
+        const y = e.clientY !== undefined ? e.clientY : e.explicitOriginalTarget.getBoundingClientRect().top + window.scrollY
+
         this.loadingRipple.open({
-            x: e.clientX,
-            y: e.clientY
+            x: x,
+            y: y
         })
             .then(() => {
                 const source = this.walletSources[type]()


### PR DESCRIPTION
It's been bugging me that when you hit enter rather than clicking the login button, the ripple comes from the top left of the screen. This change will change the source to where the cursor was when enter was hit. When clicking login the ripple source will remain as the pointer location.