### PR TITLE
Fix edit msg bug + chat-scroller arrow visibility

### DIFF
--- a/qortal-ui-plugins/plugins/core/components/ChatPage.js
+++ b/qortal-ui-plugins/plugins/core/components/ChatPage.js
@@ -2724,7 +2724,7 @@ class ChatPage extends LitElement {
             const messageObject = {
                 ...message,
                 messageText: trimmedMessage,
-                
+                isEdited: true
             }
             const stringifyMessageObject = JSON.stringify(messageObject)
             this.sendMessage(stringifyMessageObject, typeMessage, chatReference);

--- a/qortal-ui-plugins/plugins/core/components/ChatScroller.js
+++ b/qortal-ui-plugins/plugins/core/components/ChatScroller.js
@@ -150,7 +150,7 @@ class ChatScroller extends LitElement {
                             </message-template>`
                     )
                 })}
-                <div id='downObserver'></div>
+                <div style=${"height: 1px;"} id='downObserver'></div>
             </ul>
         `
     }
@@ -374,9 +374,9 @@ class MessageTemplate extends LitElement {
             repliedToData = this.messageObj.repliedToData;
             isImageDeleted = parsedMessageObj.isImageDeleted;
             reactions = parsedMessageObj.reactions || [];
-            version = parsedMessageObj.version
-            isForwarded = parsedMessageObj.type === 'forward'
-            isEdited = this.messageObj.editedTimestamp && true
+            version = parsedMessageObj.version;
+            isForwarded = parsedMessageObj.type === 'forward';
+            isEdited = parsedMessageObj.isEdited && true;
            if (parsedMessageObj.images && Array.isArray(parsedMessageObj.images) && parsedMessageObj.images.length > 0) {
                 image = parsedMessageObj.images[0];
             }


### PR DESCRIPTION
- Fixed an issue with the edited message word showing up when users reacted to a message
- Added a height to the chat scroller down observer to hide it on smaller screens