### PR TITLE
The 'X' only shows on selected tabs & hovered tabs

### DIFF
--- a/core/src/components/show-plugin.js
+++ b/core/src/components/show-plugin.js
@@ -134,6 +134,12 @@ class ShowPlugin extends connect(store)(LitElement) {
                 color: #999;
                 font-weight: bold;
                 font-size: 16px;
+                display: none;
+            }
+
+            .tab:hover .close,
+            .tab.active .close {
+                display: inline;
             }
 
             .title {


### PR DESCRIPTION
Used `display: none;` & `display: inline;` as per AlphaX's suggestion.  This automatically resizes the tab when you hover over it so the X shows nicely.