### PR TITLE
Fix 'path' missing in URL parsing

### DIFF
--- a/plugins/plugins/core/qdn/browser/browser.src.js
+++ b/plugins/plugins/core/qdn/browser/browser.src.js
@@ -270,7 +270,6 @@ class WebBrowser extends LitElement {
 			const name = parts[0]
 			parts.shift()
 			let identifier
-			let path
 			if (parts.length > 0) {
 				identifier = parts[0] // Do not shift yet
 				// Check if a resource exists with this service, name and identifier combination
@@ -286,6 +285,7 @@ class WebBrowser extends LitElement {
 					identifier = null
 				}
 			}
+			const path = parts.join("/")
 			const components = {}
 			components["service"] = service
 			components["name"] = name


### PR DESCRIPTION
This change fixes an issue that prevents `qortal://` URLs with more than three components from loading in the UI.  Currently any URL that has a "path", (text parts beyond the service, name, and identifier), does not load properly, because the `path` varible is never set to anything.  After reviewing the commit history, this seems to be a mistake that was overlooked.

`const path = parts.join("/")` was replaced with `extractComponents`: https://github.com/Qortal/qortal-ui/commit/fac7ae9004332faf1ce2071e3347a2e987ca0b54
This appears to be a typo, and was corrected several times, but only partially.

`extractComponents` was removed by two different people: https://github.com/Qortal/qortal-ui/commit/6d364168e8472fdb3322f9d09f6d5a121bb1aed0 / https://github.com/Qortal/qortal-ui/commit/fea3d16bcc131c2890e0f6f2b6f1d8ddd3fe7063

`let path` was added by three people separately: https://github.com/Qortal/qortal-ui/commit/6aad0b6e37d6e11ca24c6959845c3e540bb15d87 / https://github.com/Qortal/qortal-ui/commit/c02ffe4a72c9a711b35143d72b9ed3cd4e2385c2 / https://github.com/Qortal/qortal-ui/commit/fc17216b3a28be8eab390b2fc79c6d4909240782
These recent edits are still incomplete, as `path` remains `undefined` no matter what.