### PR TITLE
Fix "Next Level" calculations

### DIFF
--- a/plugins/plugins/core/minting/minting-info.src.js
+++ b/plugins/plugins/core/minting/minting-info.src.js
@@ -527,8 +527,8 @@ class MintingInfo extends LitElement {
     _levelUpDays() {
         let nextBatch = 1000 - (this.nodeInfo.height % 1000)
         let countBlocks = this._blocksNeed() - (this.addressInfo.blocksMinted + this.addressInfo.blocksMintedAdjustment)
-        let countBlocksActual = countBlocks + 1000 + nextBatch - (countBlocks % 1000)
-        countBlocksActual += +countBlocksActual < 0 ? 1000 : 0
+        countBlocks = +countBlocks + 1000
+        let countBlocksActual = countBlocks + nextBatch - (countBlocks % 1000)
         let countDays = (countBlocksActual / this._timeCalc()).toFixed(2)
         let countString = countDays.toString()
         return "" + countString
@@ -537,8 +537,8 @@ class MintingInfo extends LitElement {
     _levelUpBlocks() {
         let nextBatch = 1000 - (this.nodeInfo.height % 1000)
         let countBlocks = this._blocksNeed() - (this.addressInfo.blocksMinted + this.addressInfo.blocksMintedAdjustment)
-        let countBlocksActual = countBlocks + 1000 + nextBatch - (countBlocks % 1000)
-        countBlocksActual += +countBlocksActual < 0 ? 1000 : 0
+        countBlocks = +countBlocks + 1000
+        let countBlocksActual = countBlocks + nextBatch - (countBlocks % 1000)
         let countBlocksString = countBlocksActual.toString()
         return "" + countBlocksString
     }

--- a/plugins/plugins/core/minting/minting-info.src.js
+++ b/plugins/plugins/core/minting/minting-info.src.js
@@ -525,13 +525,21 @@ class MintingInfo extends LitElement {
     }
 
     _levelUpDays() {
-        let countDays = ((this._blocksNeed() - (this.addressInfo.blocksMinted + this.addressInfo.blocksMintedAdjustment)) / this._timeCalc()).toFixed(2)
-        let countString = (countDays).toString()
+        let nextBatch = 1000 - (this.nodeInfo.height % 1000)
+        let countBlocks = this._blocksNeed() - (this.addressInfo.blocksMinted + this.addressInfo.blocksMintedAdjustment)
+        let countBlocksActual = countBlocks + 1000 + nextBatch - (countBlocks % 1000)
+        countBlocksActual += +countBlocksActual < 0 ? 1000 : 0
+        let countDays = (countBlocksActual / this._timeCalc()).toFixed(2)
+        let countString = countDays.toString()
         return "" + countString
     }
 
     _levelUpBlocks() {
-        let countBlocksString = (this._blocksNeed() - (this.addressInfo.blocksMinted + this.addressInfo.blocksMintedAdjustment)).toString()
+        let nextBatch = 1000 - (this.nodeInfo.height % 1000)
+        let countBlocks = this._blocksNeed() - (this.addressInfo.blocksMinted + this.addressInfo.blocksMintedAdjustment)
+        let countBlocksActual = countBlocks + 1000 + nextBatch - (countBlocks % 1000)
+        countBlocksActual += +countBlocksActual < 0 ? 1000 : 0
+        let countBlocksString = countBlocksActual.toString()
         return "" + countBlocksString
     }
 


### PR DESCRIPTION
Anyone showing negative blocks/days to next level can please test:
https://drive.proton.me/urls/628MN572YM#HjityOTSGiwx

This fixes the Blocks/Days to Next Level on the Minting Details page, and prevents negative values.  It adds 1000 blocks, since level increases are not applied until the next batch reward block after reaching the target.  It also counts how many blocks until the next batch reward.