### PR TITLE
Show time of message edits

### DIFF
--- a/plugins/plugins/core/components/ChatScroller.js
+++ b/plugins/plugins/core/components/ChatScroller.js
@@ -1405,7 +1405,7 @@ class MessageTemplate extends LitElement {
 
 		edited = html`
 			<span class="edited-message-style">
-				${translate('chatpage.cchange68')}
+				${translate('chatpage.cchange68')} <message-time timestamp=${this.messageObj.editedTimestamp}></message-time>
 			</span>
 		`;
 


### PR DESCRIPTION
This change adds the time of the edit to any edited Q-Chat messages.  This should help prevent confusion when edits cause a "red dot", which usually indicates a new message in a group.