### PR TITLE
Add private group support to join links

### DIFF
--- a/plugins/plugins/core/components/ChatPage.js
+++ b/plugins/plugins/core/components/ChatPage.js
@@ -395,7 +395,7 @@ class ChatPage extends LitElement {
 
                     </div>
                     <div style="display: flex; height: 100%; align-items: center">
-                    ${(!this.isReceipient && +this._chatId !== 0 && this.groupInfo.isOpen) ?
+                    ${(!this.isReceipient && +this._chatId !== 0) ?
                         html`
                         <mwc-icon class="top-bar-icon" @click=${this.copyJoinGroupLinkToClipboard} style="margin: 0px 10px">link</mwc-icon>
                         `

--- a/plugins/plugins/core/group-management/group-management.src.js
+++ b/plugins/plugins/core/group-management/group-management.src.js
@@ -1847,13 +1847,7 @@ class GroupManagement extends LitElement {
                 if(sideEffectAction && sideEffectAction.type === 'openJoinGroupModal'){
                    const res = await getGroupInfo(sideEffectAction.data)
                    if(res && res.groupId){
-                    if(res.isOpen){
-                        this.joinGroup(res)
-
-                    } else {
-                        let snackbarstring = get("managegroup.mg45")
-                        parentEpml.request('showSnackBar', `${snackbarstring}`)
-                    }
+                    this.joinGroup(res)
                    }
                    window.parent.reduxStore.dispatch(
                     window.parent.reduxAction.setSideEffectAction(null)


### PR DESCRIPTION
These changes allow `qortal://use-group/action-join` links to be generated in private groups (as they are in public groups) that can be shared for others to send a JOIN_GROUP transaction.  This already works for public groups, and will result in joining the group after the transaction confirms.  For private groups, this would create a pending join request, which requires approval in Group Management from an admin.