### PR TITLE
Fix 55 years ago edit time

### DIFF
--- a/plugins/plugins/core/components/ChatScroller.js
+++ b/plugins/plugins/core/components/ChatScroller.js
@@ -1392,7 +1392,7 @@ class MessageTemplate extends LitElement {
 
 		edited = html`
 			<span class="edited-message-style">
-				${translate('chatpage.cchange68')} <message-time timestamp=${this.messageObj.editedTimestamp}></message-time>
+				${translate('chatpage.cchange68')} <message-time timestamp=${(this.messageObj.editedTimestamp === undefined ? Date.now() : this.messageObj.editedTimestamp)}></message-time>
 			</span>
 		`;
 


### PR DESCRIPTION
This fixes message edits appearing as "55 years ago" when actively viewing the message during editing.  (Messages that were previously edited when loading the chat already show the correct edit time.)