### PR TITLE
Fix voting on poll names with special characters

### DIFF
--- a/plugins/plugins/core/qdn/browser/browser.src.js
+++ b/plugins/plugins/core/qdn/browser/browser.src.js
@@ -1556,7 +1556,7 @@ class WebBrowser extends LitElement {
 					try {
 						pollInfo = await parentEpml.request("apiCall", {
 							type: "api",
-							url: `/polls/${pollName}`,
+							url: `/polls/${encodeURIComponent(pollName)}`,
 						})
 					} catch (error) {
 						const errorMsg = (error && error.message) || 'Poll not found'


### PR DESCRIPTION
When voting on a poll using qortalRequest, it first checks the poll name as a URL to verify that the poll exists.  For polls with special characters (like a question mark) this causes issues.  When trying to verify the poll, it returns that the poll does not exist.  This check can be passed within a Q-App by sending %3F instead of the ? symbol.  However, that will then also be used for the name of the poll, and the voting itself will fail, as that poll name does not exist.  This requires a change to the UI, so that the poll name can be formatted properly when checking that it exists, then it can continue with the function using the original string.  This change was tested and verified to be working properly.