### PR TITLE
Allow uppercase in some txs

### DIFF
--- a/crypto/api/transactions/groups/CreateGroupTransaction.js
+++ b/crypto/api/transactions/groups/CreateGroupTransaction.js
@@ -49,13 +49,13 @@ export default class CreateGroupTransaction extends TransactionBase {
 
 	set rGroupName(rGroupName) {
 		this._rGroupName = rGroupName
-		this._rGroupNameBytes = this.constructor.utils.stringtoUTF8Array(this._rGroupName.toLocaleLowerCase())
+		this._rGroupNameBytes = this.constructor.utils.stringtoUTF8Array(this._rGroupName)
 		this._rGroupNameLength = this.constructor.utils.int32ToBytes(this._rGroupNameBytes.length)
 	}
 
 	set rGroupDesc(rGroupDesc) {
 		this._rGroupDesc = rGroupDesc
-		this._rGroupDescBytes = this.constructor.utils.stringtoUTF8Array(this._rGroupDesc.toLocaleLowerCase())
+		this._rGroupDescBytes = this.constructor.utils.stringtoUTF8Array(this._rGroupDesc)
 		this._rGroupDescLength = this.constructor.utils.int32ToBytes(this._rGroupDescBytes.length)
 	}
 

--- a/crypto/api/transactions/groups/GroupBanTransaction.js
+++ b/crypto/api/transactions/groups/GroupBanTransaction.js
@@ -33,7 +33,7 @@ export default class GroupBanTransaction extends TransactionBase {
 
 	set rBanReason(rBanReason) {
 		this._rBanReason = rBanReason
-		this._rBanReasonBytes = this.constructor.utils.stringtoUTF8Array(this._rBanReason.toLocaleLowerCase())
+		this._rBanReasonBytes = this.constructor.utils.stringtoUTF8Array(this._rBanReason)
 		this._rBanReasonLength = this.constructor.utils.int32ToBytes(this._rBanReasonBytes.length)
 	}
 

--- a/crypto/api/transactions/groups/GroupKickTransaction.js
+++ b/crypto/api/transactions/groups/GroupKickTransaction.js
@@ -33,7 +33,7 @@ export default class GroupKickTransaction extends TransactionBase {
 
 	set rBanReason(rBanReason) {
 		this._rBanReason = rBanReason
-		this._rBanReasonBytes = this.constructor.utils.stringtoUTF8Array(this._rBanReason.toLocaleLowerCase())
+		this._rBanReasonBytes = this.constructor.utils.stringtoUTF8Array(this._rBanReason)
 		this._rBanReasonLength = this.constructor.utils.int32ToBytes(this._rBanReasonBytes.length)
 	}
 

--- a/crypto/api/transactions/groups/UpdateGroupTransaction.js
+++ b/crypto/api/transactions/groups/UpdateGroupTransaction.js
@@ -35,7 +35,7 @@ export default class UpdateGroupTransaction extends TransactionBase {
     }
 
     set newDescription(newDescription) {
-        this._rGroupDescBytes = this.constructor.utils.stringtoUTF8Array(newDescription.toLocaleLowerCase())
+        this._rGroupDescBytes = this.constructor.utils.stringtoUTF8Array(newDescription)
         this._rGroupDescLength = this.constructor.utils.int32ToBytes(this._rGroupDescBytes.length)
     }
 

--- a/crypto/api/transactions/polls/CreatePollTransaction.js
+++ b/crypto/api/transactions/polls/CreatePollTransaction.js
@@ -75,7 +75,7 @@ export default class CreatePollTransaction extends TransactionBase {
 
 	set rPollDesc(rPollDesc) {
 		this._rPollDesc = rPollDesc
-		this._rPollDescBytes = this.constructor.utils.stringtoUTF8Array(this._rPollDesc.toLocaleLowerCase())
+		this._rPollDescBytes = this.constructor.utils.stringtoUTF8Array(this._rPollDesc)
 		this._rPollDescLength = this.constructor.utils.int32ToBytes(this._rPollDescBytes.length)
 	}
 


### PR DESCRIPTION
This allows for uppercase letters in Group Names, Group Descriptions, Poll Descriptions, and Kick / Ban Reasons.  There is no need or purpose to make these strings lowercase.  The Core already checks a "reduced" version for account Names and Group Names, which are the ones that need to avoid duplicates.

https://github.com/Qortal/qortal/blob/master/src/main/java/org/qortal/data/transaction/CreateGroupTransactionData.java
`this.reducedGroupName = Unicode.sanitize(this.groupName);`

The AT Name, Description, and Tags are made lowercase too, but there may be some services that depend on those strings staying the same, so it might be better not to change those without more consideration.

EDIT:  This has been tested which can be seen here:
[Uppercase Group Name](https://api.qortal.org/groups/629)
[Uppercase Kick Reason](https://api.qortal.org/transactions/reference/5ZVbpmpai3C7h2LNNQ44nKhgFBa7sDj3waw96VNLSkXhvcgpoA1wzEKXQewNrigwLRXgx8uMsgdyKVUd17sBjLsN)

This solves the following Issues as well:
https://github.com/Qortal/qortal-ui/issues/162 & https://github.com/Qortal/qortal/issues/121