### PR TITLE
Update blocksBehind from 1050 to 8500 in sync-indicator.js

### DIFF
--- a/core/src/components/beginner-tour/sync-indicator.js
+++ b/core/src/components/beginner-tour/sync-indicator.js
@@ -103,7 +103,7 @@ class SyncIndicator extends connect(store)(LitElement) {
 						${translate("tour.tour17")}
 					</p>
 				</div>
-			` : (this.blocksBehind > 1050 && this.isSynchronizing) ? html`
+			` : (this.blocksBehind > 8500 && this.isSynchronizing) ? html`
 				<div class="parent">
 					<div class="column">
 						<div class="row">


### PR DESCRIPTION
When you are behind by 1050 blocks a message pops up, asking if you'd like to bootstrap.  I recently bootstrapped, and when it was done, I was behind then 3300 blocks.  This is a flaw, and the message promotes speeding this up, but does not, it makes it take longer.

The solution to this is to only show this message when you are much farther behind.  With an average daily block rate of 1,222 blocks, and an average bootstrap update period of 1 week, this means the maximum a bootstrap will be behind is about 8500 blocks.  Consequently, it would make more sense to set this number to precisely that.

The code I changed was simply just 1050 to 8500 as this makes much more sense practicality wise.