### PR TITLE
Add message content to modal

### DIFF
--- a/plugins/plugins/core/qdn/browser/browser.src.js
+++ b/plugins/plugins/core/qdn/browser/browser.src.js
@@ -3724,6 +3724,7 @@ async function showModalAndWait(type, data) {
 
 						${type === actions.SEND_CHAT_MESSAGE ? `
 							<p class="modal-paragraph">${get("browserpage.bchange22")}</p>
+							<p class="modal-paragraph">${get("chatpage.cchange4")}: <span> ${data.message}</span></p>
 						` : ''}
 					</div>
 					<div class="modal-buttons">


### PR DESCRIPTION
@QortalSeth - This adds a new paragraph to the modal when approving the SEND_CHAT_MESSAGE qortalRequest action, which displays the content of the chat message.  This resolves the following open issue:  https://github.com/Qortal/qortal-ui/issues/307