### PR TITLE
Remove character limit on name search

### DIFF
--- a/core/src/components/search-modal.js
+++ b/core/src/components/search-modal.js
@@ -74,7 +74,7 @@ class SearchModal extends LitElement {
 	openUserInfo() {
 		const checkvalue = this.shadowRoot.getElementById('searchContent').value
 
-		if (checkvalue.length < 3) {
+		if (checkvalue.length < 1) {
 			let snackbar1string = get("publishpage.pchange20")
 			let snackbar2string = get("welcomepage.wcchange4")
 


### PR DESCRIPTION
When searching for a registered name in the UI using the magnifying glass in the top bar, users are restricted to searching for names that are 3 characters or longer.  This appears to be an arbitrary limit, and prevents people from being able to look up names that are 1 or 2 characters, of which there are many registered already.  This pull request changes the search limit to "1 or more characters" meaning it will only give an error if the search query is 0 characters, or empty.