### PR TITLE
Add label to theme toggle

### DIFF
--- a/core/src/components/qort-theme-toggle.js
+++ b/core/src/components/qort-theme-toggle.js
@@ -20,7 +20,12 @@ class QortThemeToggle extends LitElement {
 
 	render() {
 		return html`
-			<input type="checkbox" @change=${() => this.toggleTheme()}/>
+			<input 
+				type="checkbox" 
+				role="switch" 
+				aria-label="Dark theme" 
+				@change=${() => this.toggleTheme()}
+			/>
 			<div class="slider"></div>
 			<div class="icon">
 				<span class="sun">${svgSun}</span>


### PR DESCRIPTION
Currently when using the UI with a screen reader, the theme toggle has a generic description of "Checkbox" and a state of "Checked" or "Unchecked".  This commit will change that description to say "Dark Theme" and the switch role causes the state to be read as "On" or "Off".  This was tested using `orca` on Linux.  For Windows, NVDA is used and recommended by someone in the community.